### PR TITLE
Fix generate-sitemap.yml to commit and push

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -3,6 +3,7 @@ name: Generate xml sitemap
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   sitemap_job:
@@ -11,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0 
 
@@ -26,10 +27,13 @@ jobs:
         echo "sitemap-path = ${{ steps.sitemap.outputs.sitemap-path }}"
         echo "url-count = ${{ steps.sitemap.outputs.url-count }}"
         echo "excluded-count = ${{ steps.sitemap.outputs.excluded-count }}"
-    
-    - name: Update resources
-      uses: cicirello/generate-sitemap@v1
-      with:
-        file-path: /sitemap.xml
-        commit-msg: Update resources
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Commit and push
+      run: |
+        if [[ `git status --porcelain sitemap.xml` ]]; then
+          git config --global user.name 'Daniel Roberts'
+          git config --global user.email 'BlenderTimer@users.noreply.github.com'
+          git add sitemap.xml
+          git commit -m "Automated sitemap update" sitemap.xml
+          git push
+        fi


### PR DESCRIPTION
## What I Did
There are a couple updates to your workflow:
1. Updated version of the GitHub checkout action to v3.
2. Added an additional event to the workflow, specifically `workflow_dispatch`, which enables you to run the workflow manually from the Actions tab if you find reason to update the sitemap other than by a push.
3. I added a step at the end that should commit and push the sitemap if it is different than the version in your main branch.

## If you merge this:
1. If you merge this, then the workflow will run since you have an event push configured, and I think it should fix the issue.
2. On any future pushes, it will likewise run.
3. If you want to run it manually, go to the Actions tab, find the workflow on the right, and then click "run".